### PR TITLE
Array ref bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.venv/
 node_modules
 package-lock.json

--- a/example.js
+++ b/example.js
@@ -1,25 +1,14 @@
 var test = require('tape'),
     estktap = require(__dirname);
 
-test('extendscript tap test',function(t){
-  estktap('this must be true',__dirname+'/test/fixtures/test/test.jsx',true);
-  t.end();
-});
+var targets = ['indesign-12'];
 
-test('extendscript tap test with target',function(t){
-  estktap('this must be true',__dirname+'/test/fixtures/test/test.jsx',true,['indesign-13']);
+test('extendscript tap test',function(t){
+  estktap('this must be true',__dirname+'/test/fixtures/test/test.jsx',true,targets);
   t.end();
 });
 
 test('extendscript tap test with function',function(t){
-  estktap('deepEqual',__dirname+'/test/fixtures/test/obj.jsx',function(d){
-    t.deepEqual(d,{x:0, y:0, width:3000, height: 5000});
-  });
-  t.end();
-});
-
-test('extendscript tap test with multiple targets and function',function(t){
-  var targets = ['indesign-11','indesign-13'];
   estktap('deepEqual',__dirname+'/test/fixtures/test/obj.jsx',function(d){
     t.deepEqual(d,{x:0, y:0, width:3000, height: 5000});
   },targets);

--- a/index.js
+++ b/index.js
@@ -5,18 +5,18 @@ module.exports = estktap;
 
 function estktap(mes,script,is_a,targets){
   // param target is optional and can be undefined
-  if( !Array.isArray(targets) ) targets = ["undefined"];
+  var targetArr = ( Array.isArray(targets) )? targets.slice(0) : ["undefined"];
   // Shift params
-  if( Array.isArray(is_a) ) targets = is_a, is_a = undefined;
-  
-  var tLen = targets.length;
+  if( Array.isArray(is_a) ) targetArr = is_a.slice(0), is_a = undefined;
+
+  var tLen = targetArr.length;
   // Index array for asynchronous pooping
   var targetIndex = Array.apply(null, {length: tLen}).map(Number.call, Number);
   
   if(typeof is_a !== 'function'){
     tape(mes,function(t){
       for (var i = 0; i < tLen; i++) { 
-        fakestk.run(script,targets.pop(),function(err,res){
+        fakestk.run(script,targetArr.pop(),function(err,res){
           if(err) return t.fail(err);
           var jsobj = (new Function('return '+res))();
           t.equal(jsobj,is_a,mes);
@@ -27,7 +27,7 @@ function estktap(mes,script,is_a,targets){
   }else{
     tape(mes,function(t){
       for (var i = 0; i < tLen; i++) {
-        fakestk.run(script,targets.pop(),function(err,res){
+        fakestk.run(script,targetArr.pop(),function(err,res){
           if(err) return t.fail(err);
           var jsobj = (new Function('return '+res))();
           is_a(jsobj);

--- a/infoHelper.jsx
+++ b/infoHelper.jsx
@@ -1,0 +1,7 @@
+$.writeln($.os);
+try {
+    $.writeln(app.name + ' ' + app.build);
+} catch (e) {
+    $.writeln(app.name + ' ' + app.version);
+}
+$.writeln('Javascript version ' + $.version);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "estktap",
   "description": "tap(tape) wrapper for testing adobe extendscript",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "nbqx",
   "repository": {
     "type": "git",

--- a/test/fixtures/output.txt
+++ b/test/fixtures/output.txt
@@ -1,21 +1,14 @@
 TAP version 13
 # extendscript tap test
-# extendscript tap test with target
 # extendscript tap test with function
-# extendscript tap test with multiple targets and function
 # this must be true
 ok 1 this must be true
-# this must be true
-ok 2 this must be true
 # deepEqual
-ok 3 should be equivalent
-# deepEqual
-ok 4 should be equivalent
-ok 5 should be equivalent
+ok 2 should be equivalent
 
-1..5
-# tests 5
-# pass  5
+1..2
+# tests 2
+# pass  2
 
 # ok
 


### PR DESCRIPTION
Arrays are passed by reference so we where popping the target array from caller. Causing problems with subsequent tests. Fixed now! Also simplifies tests to use global variable as well. The readme states
clearly that targets are optional.