### PR TITLE
Pass test object `t` to comparator `is_a`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 .*.jsx
-.venv/
 node_modules
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.*.jsx
 .venv/
 node_modules
 package-lock.json

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-var test = require('tape'),
+var test = require('tape-catch'),
     estktap = require(__dirname);
 
 var targets = ['indesign-12'];

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function estktap(mes,script,is_a,targets){
         fakestk.run(script,targetArr.pop(),function(err,res){
           if(err) return t.fail(err);
           var jsobj = (new Function('return '+res))();
-          is_a(jsobj);
+          is_a(jsobj, t);
           if(targetIndex.pop() === 0) t.end();
         });
       };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var tape =  require('tape'),
+var tape =  require('tape-catch'),
     fakestk = require('fakestk');
 
 module.exports = estktap;

--- a/infoHelper.jsx
+++ b/infoHelper.jsx
@@ -1,7 +1,0 @@
-$.writeln($.os);
-try {
-    $.writeln(app.name + ' ' + app.build);
-} catch (e) {
-    $.writeln(app.name + ' ' + app.version);
-}
-$.writeln('Javascript version ' + $.version);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "estktap",
   "description": "tap(tape) wrapper for testing adobe extendscript",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "nbqx",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fakestk": "^0.3.4",
-    "tape": "^2.12.3"
+    "fakestk": "^0.3.5",
+    "tape": "^4.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "fakestk": "^0.3.5",
-    "tape": "^4.9.0"
+    "tape": "^4.9.0",
+    "tape-catch": "^1.0.6"
   }
 }


### PR DESCRIPTION
## Change
Pass target object to comparator so we can generate tests automatically. As this is passed as a new second arguments this is backwards compatible.

## Housekeeping
  - Clean up helper file (`infoHelper.jsx`) and remove `.venv` from `.gitIgnore` as it should not be part of this repo
  - Don't commit hidden temporary scripts to git (`.*.jsx`)
 